### PR TITLE
fix: Remove Gmail specific CHECK response check

### DIFF
--- a/custom_components/ocado/config_flow.py
+++ b/custom_components/ocado/config_flow.py
@@ -82,7 +82,7 @@ async def _validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str
         _LOGGER.exception("Failed to select imap folder or check")
         raise Exception
     _LOGGER.debug("Checking the check: %s", check)
-    if check != ('OK', [b'Success']):
+    if not check or check[0] != 'OK':
         _LOGGER.exception("Check failed")
         raise Exception
     return {"title": f"Ocado Integration - {data[CONF_EMAIL]}:{data[CONF_IMAP_SERVER]}"}


### PR DESCRIPTION
Fixes #1 

[RFC 3501](https://datatracker.ietf.org/doc/html/rfc3501#section-6.4.1) does not specify what data is returned in response to a CHECK, and it appears that IMAP server implementations vary:

- Gmail returns 'Success'
- Fastmail returns 'Completed'

Remove the check for data and assume the response type 'OK' is enough.