### PR TITLE
fix: Support "Order Reference: <>" email format

### DIFF
--- a/custom_components/ocado/manifest.json
+++ b/custom_components/ocado/manifest.json
@@ -14,5 +14,5 @@
       "python-dateutil==2.9.0"
     ],
     "single_config_entry": true,    
-    "version": "1.0.7"
+    "version": "1.0.8"
   }

--- a/custom_components/ocado/utils.py
+++ b/custom_components/ocado/utils.py
@@ -108,7 +108,7 @@ def get_edit_datetime(message: str) -> datetime:
 
 def get_order_number(message: str) -> str:
     """Parse the order number."""
-    raw = re.search(r"(?:Order\sref\.:)?(?:Order\sis\s)?(?:\s{1,20})(?P<order_number>\d{10})",message)
+    raw = re.search(r"(?:Order\sref(\.|erence):)?(?:Order\sis\s)?(?:\s{1,20})(?P<order_number>\d{10})",message)
     if raw:
         return raw.group('order_number')
     _LOGGER.error("No order number retrieved from message %s.", message[:20])


### PR DESCRIPTION
My emails have the order number in this format:

![2025_05_26_16_11_45_LibreWolf](https://github.com/user-attachments/assets/cac28073-cda8-4e87-8165-19a6b1a1cb5f)
